### PR TITLE
Add command-line usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/elb-log-parser.png)](https://badge.fury.io/js/elb-log-parser)
 [![Build Status](https://travis-ci.org/toshihirock/node-elb-log-parser.svg?branch=master)](https://travis-ci.org/toshihirock/node-elb-log-parser)
 
-A basic parser for ELB access logs, strongly inspired by node-clf-parser https://github.com/jfhbrook/node-clf-parser 
+A basic parser for ELB access logs, strongly inspired by node-clf-parser https://github.com/jfhbrook/node-clf-parser.
 
 ## When I use this npm?
 
@@ -13,10 +13,17 @@ A basic parser for ELB access logs, strongly inspired by node-clf-parser https:/
 ## Install
 
 ```
-$npm install elb-log-parser
+npm install -g elb-log-parser
 ```
 
-## Example
+## Example command-line usage
+
+```
+906058675309_elasticloadbalancing_us-east-1_my-elb_20160420T1700Z_10.0.33.113_115hdtdv.log > elb-log-parser
+```
+Outputs JSON which can then be further processed with e.g. something like the [json](https://www.npmjs.com/package/json) tool.
+
+## Example API usage
 
 ```
 node-elb-log-parser$node

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 module.exports = function (line) {
   var parsed = {};
   var url = require('url');
@@ -103,3 +104,20 @@ module.exports = function (line) {
 
   return parsed;
 };
+
+if (require.main === module) {
+  var split = require('split');
+  var Transform = require('stream').Transform;
+  process.stdin
+    .pipe(split())
+    .pipe(new Transform({
+      decodeStrings: false,
+      transform: function (line, encoding, callback) {
+        if (line) {
+          this.push(JSON.stringify(module.exports(line)) + '\n');
+        }
+        callback();
+      }
+    }))
+    .pipe(process.stdout);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.2",
   "description": "A basic parser for ELB access logs, strongly inspired by node-clf-parser https://github.com/jfhbrook/node-clf-parser",
   "main": "index.js",
+  "bin": {
+    "elb-log-parser": "index.js"
+  },
   "scripts": {
     "test": "node ./test.js"
   },
@@ -20,5 +23,8 @@
   "license": "MIT",
   "devDependencies": {
     "tap": "~0.4.3"
+  },
+  "dependencies": {
+    "split": "^1.0.0"
   }
 }


### PR DESCRIPTION
Command-line `elb-log-parser` consumes log lines and outputs JSON lines
in the standard unix style.
