### PR TITLE
ignores ELBAccessLogTestFile that ELB creates

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (line) {
   var parsed = {};
   var url = require('url');
 
-  var request_labels = 
+  var request_labels =
   [
     'request_method',
     'request_uri',
@@ -15,6 +15,12 @@ module.exports = function (line) {
     'request_uri_query'
   ];
 
+  //
+  // Ignore ELBAccessLogTestFile
+  //
+  if (line.match(/^Enable AccessLog for ELB:/)) {
+    return parsed;
+  }
   //
   // Trailing newline? NOTHX
   //


### PR DESCRIPTION
When you enable Access Logs in AWS ELB, it will create ELBAccessLogTestFile into S3 bucket.
This pull request will identify that line based on its content, skip it and that way avoid problems that come from broken syntax in test file.
