### PR TITLE
add error processing for stdout closing, such as on head -1

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (line) {
   var parsed = {};
   var url = require('url');
 
-  var request_labels = 
+  var request_labels =
   [
     'request_method',
     'request_uri',
@@ -104,6 +104,16 @@ module.exports = function (line) {
 
   return parsed;
 };
+
+process.stdout.on('error', function(err) {
+  running = false;
+  if(err.code === 'EPIPE') {
+    process.exit(0);
+  } else {
+    process.stderr.write(JSON.stringify(err) + '\n');
+    process.exit(1);
+  }
+})
 
 if (require.main === module) {
   var split = require('split');


### PR DESCRIPTION
When piping the output through a program that might close the stdout file descriptor, such as `head -1` you would be presented with an EPIPE error:
```
events.js:182
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at exports._errnoException (util.js:1024:11)
    at WriteWrap.afterWrite [as oncomplete] (net.js:851:14)
```
This PR fixes that