### PR TITLE
TypeError: Cannot read property 'split' of undefined #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = function (line) {
   });
 
   // backend
-  if( typeof parsed.backend !== 'undefined' && parsed.backend != -1) {
+  if (typeof parsed.backend !== 'undefined' && parsed.backend != -1) {
     parsed['backend_port'] = parsed.backend.split(":")[1];
     parsed['backend'] = parsed.backend.split(":")[0];
   } else {
@@ -74,7 +74,7 @@ module.exports = function (line) {
   }
 
   // request
-  if(parsed.request != '- - - ') {
+  if (typeof parsed.request !== 'undefined' && parsed.request != '- - - ') {
     var i = 0;
     var method = parsed.request.split(" ")[0];
     var url = url.parse(parsed.request.split(" ")[1]);
@@ -96,7 +96,7 @@ module.exports = function (line) {
     i++;
     parsed[request_labels[i]] = url.query;
 
-  } else {
+  } else if (typeof parsed.request !== 'undefined') {
     request_labels.forEach(function(label) {
       parsed[label] = '-';
     });

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (line) {
   var parsed = {};
   var url = require('url');
 
-  var request_labels = 
+  var request_labels =
   [
     'request_method',
     'request_uri',
@@ -66,7 +66,7 @@ module.exports = function (line) {
   });
 
   // backend
-  if(parsed.backend != -1) {
+  if( typeof parsed.backend !== 'undefined' && parsed.backend != -1) {
     parsed['backend_port'] = parsed.backend.split(":")[1];
     parsed['backend'] = parsed.backend.split(":")[0];
   } else {


### PR DESCRIPTION
getting these errors calling this npm from the code at
https://github.com/prithviraju/aws-elb-logs-to-elasticsearch/blob/master/index.js

TypeError: Cannot read property 'split' of undefined
at module.exports (/var/task/node_modules/elb-log-parser/index.js:69:45)
at Transform.recordStream._transform (/var/task/index.js:148:25)
at Transform._read (_stream_transform.js:186:10)
at Transform._write (_stream_transform.js:174:12)
at doWrite (_stream_writable.js:397:12)
at writeOrBuffer (_stream_writable.js:383:5)
at Transform.Writable.write (_stream_writable.js:290:11)
at LineStream.ondata (_stream_readable.js:639:20)
at emitOne (events.js:116:13)
at LineStream.emit (events.js:211:7)

happen on line:
parsed['backend_port'] = parsed.backend.split(":")[1];